### PR TITLE
register api groups to `legacyscheme.Scheme` early

### DIFF
--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -1,0 +1,6 @@
+package install
+
+import (
+	_ "github.com/openshift/oauth-apiserver/pkg/oauth/apis/oauth/install"
+	_ "github.com/openshift/oauth-apiserver/pkg/user/apis/user/install"
+)

--- a/pkg/cmd/oauth-apiserver/cmd.go
+++ b/pkg/cmd/oauth-apiserver/cmd.go
@@ -21,6 +21,9 @@ import (
 	"github.com/openshift/oauth-apiserver/pkg/cmd/oauth-apiserver/openapiconfig"
 	"github.com/openshift/oauth-apiserver/pkg/serverscheme"
 
+	// register api groups
+	_ "github.com/openshift/oauth-apiserver/pkg/api/install"
+
 	// to force compiling
 	_ "github.com/openshift/oauth-apiserver/pkg/oauth/apiserver"
 	_ "github.com/openshift/oauth-apiserver/pkg/user/apiserver"

--- a/pkg/oauth/apis/oauth/install/install.go
+++ b/pkg/oauth/apis/oauth/install/install.go
@@ -3,10 +3,15 @@ package install
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	oauthapiv1 "github.com/openshift/oauth-apiserver/pkg/oauth/apis/oauth/v1"
 )
+
+func init() {
+	Install(legacyscheme.Scheme)
+}
 
 // Install registers the API group and adds types to a scheme
 func Install(scheme *runtime.Scheme) {

--- a/pkg/user/apis/user/install/install.go
+++ b/pkg/user/apis/user/install/install.go
@@ -3,10 +3,15 @@ package install
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	userv1 "github.com/openshift/api/user/v1"
 	userapiv1 "github.com/openshift/oauth-apiserver/pkg/user/apis/user/v1"
 )
+
+func init() {
+	Install(legacyscheme.Scheme)
+}
 
 // Install registers the API group and adds types to a scheme
 func Install(scheme *runtime.Scheme) {


### PR DESCRIPTION
all sort of things rely on the types being registered into the scheme without it bad things can happen.

for example, the type namer used to construct the OpenAPI spec uses it to build its internal state.
The final spec might be incomplete if not all types were registered.

Co-authored-by:  Maru Newby <marun@redhat.com>

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1894342