### PR TITLE
add a custom authorizer to ensure kube-apiserver can always access tokenreviews webhook

### DIFF
--- a/pkg/authorization/hardcodedauthorizer/tokenreview.go
+++ b/pkg/authorization/hardcodedauthorizer/tokenreview.go
@@ -1,0 +1,41 @@
+package hardcodedauthorizer
+
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type tokenReviewAuthorizer struct{}
+
+// GetUser() user.Info - checked
+// GetVerb() string - checked
+// IsReadOnly() bool - na
+// GetNamespace() string - checked
+// GetResource() string - checked
+// GetSubresource() string - checked
+// GetName() string - na
+// GetAPIGroup() string - checked
+// GetAPIVersion() string - na
+// IsResourceRequest() bool - checked
+// GetPath() string - na
+func (tokenReviewAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if a.GetUser().GetName() != "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator" {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+	if a.IsResourceRequest() &&
+		a.GetVerb() == "create" &&
+		a.GetAPIGroup() == "oauth.openshift.io" &&
+		a.GetResource() == "tokenreviews" &&
+		len(a.GetSubresource()) == 0 &&
+		len(a.GetNamespace()) == 0 {
+		return authorizer.DecisionAllow, "requesting tokenreviews is allowed", nil
+	}
+
+	return authorizer.DecisionNoOpinion, "", nil
+}
+
+// NewHardCodedTokenReviewAuthorizer returns an authorizer that allows the expected kube-apiserver user to run tokenreviews.
+func NewHardCodedTokenReviewAuthorizer() *tokenReviewAuthorizer {
+	return new(tokenReviewAuthorizer)
+}

--- a/pkg/authorization/hardcodedauthorizer/tokenreview_test.go
+++ b/pkg/authorization/hardcodedauthorizer/tokenreview_test.go
@@ -1,0 +1,69 @@
+package hardcodedauthorizer
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestAuthorizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		authorizer authorizer.Authorizer
+
+		shouldPass      []authorizer.Attributes
+		shouldNoOpinion []authorizer.Attributes
+	}{
+		{
+			name:       "tokens",
+			authorizer: NewHardCodedTokenReviewAuthorizer(),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
+					Verb: "create", APIGroup: "oauth.openshift.io", Resource: "tokenreviews", Subresource: "", ResourceRequest: true},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// wrong user
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "other"},
+					Verb: "create", APIGroup: "oauth.openshift.io", Resource: "tokenreviews", Subresource: "", ResourceRequest: true},
+
+				// wrong verb
+				authorizer.AttributesRecord{
+					User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
+					Verb: "update", APIGroup: "oauth.openshift.io", Resource: "tokenreviews", Subresource: "", ResourceRequest: true},
+				// wrong group
+				authorizer.AttributesRecord{
+					User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
+					Verb: "get", APIGroup: "k8s.io", Resource: "tokenreviews", Subresource: "", ResourceRequest: true},
+				// wrong resource
+				authorizer.AttributesRecord{
+					User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
+					Verb: "get", APIGroup: "oauth.openshift.io", Resource: "other-resource", Subresource: "", ResourceRequest: true},
+				// wrong subresource
+				authorizer.AttributesRecord{
+					User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"},
+					Verb: "get", APIGroup: "oauth.openshift.io", Resource: "tokenreviews", Subresource: "foo", ResourceRequest: true},
+
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-oauth-apiserver:openshift-authenticator"}, Verb: "get", Path: "/api"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, attr := range tt.shouldPass {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionAllow {
+					t.Errorf("incorrectly restricted %v", attr)
+				}
+			}
+
+			for _, attr := range tt.shouldNoOpinion {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionNoOpinion {
+					t.Errorf("incorrectly opinionated %v", attr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a hardcoded authorizer to avoid unnecessary SAR calls.  This could be made generic.  We could also add one for handling /metrics