### PR TITLE
Bug 1955435: Do not validate kube:admin user

### DIFF
--- a/pkg/oauth/apis/oauth/validation/validation_test.go
+++ b/pkg/oauth/apis/oauth/validation/validation_test.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -744,5 +746,33 @@ func TestValidateAuthorizeTokensUpdate(t *testing.T) {
 				t.Errorf("%s: expected errors to have field %s: %v", k, v.F, errs[i])
 			}
 		}
+	}
+}
+
+func TestValidateUserNameField(t *testing.T) {
+	fieldPath := field.NewPath("metadata", "name")
+	tests := []struct {
+		username string
+		want     field.ErrorList
+	}{
+		{
+			username: "john",
+			want:     field.ErrorList{},
+		},
+		{
+			username: "kube:admin",
+			want:     field.ErrorList{},
+		},
+		{
+			username: "system:admin",
+			want:     field.ErrorList{field.Invalid(fieldPath, "system:admin", strings.Join([]string{`usernames that contain ":" must begin with "b64:"`}, ", "))},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.username, func(t *testing.T) {
+			if got := ValidateUserNameField(tt.username, fieldPath); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateUserNameField() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1955435

This Pull Request prevents `kube:admin` user from failing with validation. 

Steps to verify this patch on a running server:
- Option 1 - observe the audit logs in the oAuth API Server logs and log in as `kubeadmin`. Note, there's no audit error emitted.
- Option 2 - use the following command and observe the output (note, there's no error):

```
$ oc get --raw /apis/user.openshift.io/v1/users/kube:admin
Error from server (NotFound): users.user.openshift.io "kube:admin" not found
```