### PR TITLE
registry: audit deleted access/authorize tokens

### DIFF
--- a/pkg/oauth/apiserver/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/apiserver/registry/oauthaccesstoken/etcd/etcd.go
@@ -40,9 +40,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter, clientGetter oauthclient.Gett
 			return expires, nil
 		},
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ReturnDeletedObject: true,
 	}
 
 	options := &generic.StoreOptions{

--- a/pkg/oauth/apiserver/registry/oauthauthorizetoken/etcd/etcd.go
+++ b/pkg/oauth/apiserver/registry/oauthauthorizetoken/etcd/etcd.go
@@ -39,9 +39,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter, clientGetter oauthclient.Gett
 			return expires, nil
 		},
 
-		CreateStrategy: strategy,
-		UpdateStrategy: strategy,
-		DeleteStrategy: strategy,
+		CreateStrategy:      strategy,
+		UpdateStrategy:      strategy,
+		DeleteStrategy:      strategy,
+		ReturnDeletedObject: true,
 	}
 
 	options := &generic.StoreOptions{


### PR DESCRIPTION
Currently, we do not have the full token available in audit logs
in case of deletions.

This is necessary though as for logouts deletion of tokens is the
only indicator of such events.

This fixes it.