### PR TITLE
[release-4.7][ART-3664] Bug 2043804: IPs with leading zeros are still valid in the apiserver

### DIFF
--- a/images/Dockerfile.rhel7
+++ b/images/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/oauth-apiserver
 COPY . .
-RUN make build --warn-undefined-variables
+RUN make GOFLAGS='-mod=vendor -p=4 -tags=unsupportedGolang115OnlyUseDeprecatedParseIPv4' build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/openshift/oauth-apiserver/oauth-apiserver /usr/bin/


### PR DESCRIPTION
ref https://issues.redhat.com/browse/ART-3664

/assign s-urbaniak 

backport of https://github.com/openshift/oauth-apiserver/pull/74, copied from there:
> 1. If the Bugzilla associated with the PR has the "FastFix" keyword, the subjective assessment on the issue has already been done and a customer is impacted. These PRs should be prioritized for merge.
>    * [x]  does not apply
> 2. The bug has significant impact either through severity, reduction in supportability, or number of users affected.
>    * [x]  verified
> 3. For branches that are in the Maintenance lifecycle phase:
>    * [x]  The bug is a security related bug
>    * [x]  Branch not in maintenance mode yet (current release + previous release for 90 days after current GA; everything older is in maintenance)
> 4. The severity field of the bug must be set to accurately reflect criticality.
>    * [x]  verified
> 5. The PR was created with the cherry-pick bot OR the PR’s description is well formed with user-focused release notes that state the bug number, impact, cause, and resolution. Where appropriate, it should also contain information about how a user can identify whether a particular cluster is affected.
>    * [x]  verified
