### PR TITLE
NO-ISSUE: oauth-apiserver: allow disabling PriorityAndFairness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ replace (
 	k8s.io/api => k8s.io/api v0.28.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.3
 	k8s.io/apimachinery => k8s.io/apimachinery v0.28.3
-	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20240112142943-d5600c13f38a // points to openshift-apiserver-4.15-kubernetes-1.28.3
+	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20240312083446-be9e4a60dde6 // points to openshift-apiserver-4.15-kubernetes-1.28.3
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.28.3
 	k8s.io/client-go => k8s.io/client-go v0.28.3
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3 h1:uVCq/Sx2y4U
 github.com/openshift/client-go v0.0.0-20230607134213-3cd0021bbee3/go.mod h1:M+VUIcqx5IvgzejcbgmQnxETPrXRYlcufHpw2bAgz9Y=
 github.com/openshift/kubernetes v0.0.0-20231102175044-c01bd450743e h1:VQAVi9Vw2OaxXJtQd/uB3qozjxh19cZSjA4Phnf/kSM=
 github.com/openshift/kubernetes v0.0.0-20231102175044-c01bd450743e/go.mod h1:NhAysZWvHtNcJFFHic87ofxQN7loylCQwg3ZvXVDbag=
-github.com/openshift/kubernetes-apiserver v0.0.0-20240112142943-d5600c13f38a h1:M9I+ouvdUpNBV9+uwOSFhvB1dzmH7mmQkLOf9s4TT5M=
-github.com/openshift/kubernetes-apiserver v0.0.0-20240112142943-d5600c13f38a/go.mod h1:YIpM+9wngNAv8Ctt0rHG4vQuX/I5rvkEMtZtsxW2rNM=
+github.com/openshift/kubernetes-apiserver v0.0.0-20240312083446-be9e4a60dde6 h1:bUfuVavvVf50gtwxFYtQoPZWl1foEPVsKzQr/Ix0qPg=
+github.com/openshift/kubernetes-apiserver v0.0.0-20240312083446-be9e4a60dde6/go.mod h1:YIpM+9wngNAv8Ctt0rHG4vQuX/I5rvkEMtZtsxW2rNM=
 github.com/openshift/library-go v0.0.0-20230808150704-ce4395c85e8c h1:UJjxHFSTcasHxRXtDc3od9p7UJUBJxUKjhZHFyp2uUQ=
 github.com/openshift/library-go v0.0.0-20230808150704-ce4395c85e8c/go.mod h1:ZFwNwC3opc/7aOvzUbU95zp33Lbxet48h80ryH3p6DY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/cmd/oauth-apiserver/cmd_test.go
+++ b/pkg/cmd/oauth-apiserver/cmd_test.go
@@ -81,7 +81,6 @@ func TestAddFlags(t *testing.T) {
 			JSONPatchMaxCopyBytes:       int64(3 * 1024 * 1024),
 			MaxRequestBodyBytes:         int64(3 * 1024 * 1024),
 			ShutdownSendRetryAfter:      true,
-			EnablePriorityAndFairness:   true,
 		},
 		RecommendedOptions: &genericapiserveroptions.RecommendedOptions{
 			Etcd: &genericapiserveroptions.EtcdOptions{
@@ -177,7 +176,8 @@ func TestAddFlags(t *testing.T) {
 				},
 			},
 			Features: &genericapiserveroptions.FeatureOptions{
-				EnableProfiling: true,
+				EnableProfiling:           true,
+				EnablePriorityAndFairness: true,
 			},
 			CoreAPI: &genericapiserveroptions.CoreAPIOptions{},
 			Admission: &genericapiserveroptions.AdmissionOptions{
@@ -238,6 +238,7 @@ func TestOAuthAPIServerConfig(t *testing.T) {
 		"--shutdown-send-retry-after=true",
 		"--secure-port=0",
 		"--kubeconfig", fakeKubeConfigPath,
+		"--enable-priority-and-fairness=false",
 	}
 
 	// act
@@ -261,5 +262,8 @@ func TestOAuthAPIServerConfig(t *testing.T) {
 	}
 	if !target.GenericConfig.ShutdownSendRetryAfter {
 		t.Fatal("expected target.GenericConfig.ShutdownSendRetryAfter to be true")
+	}
+	if target.GenericConfig.FlowControl != nil {
+		t.Fatal("PriorityAndFairness wasn't disabled")
 	}
 }

--- a/vendor/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/feature.go
@@ -17,16 +17,24 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/util/feature"
+	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 )
 
 type FeatureOptions struct {
 	EnableProfiling           bool
 	DebugSocketPath           string
 	EnableContentionProfiling bool
+	EnablePriorityAndFairness bool
 }
 
 func NewFeatureOptions() *FeatureOptions {
@@ -36,6 +44,7 @@ func NewFeatureOptions() *FeatureOptions {
 		EnableProfiling:           defaults.EnableProfiling,
 		DebugSocketPath:           defaults.DebugSocketPath,
 		EnableContentionProfiling: defaults.EnableContentionProfiling,
+		EnablePriorityAndFairness: true,
 	}
 }
 
@@ -50,9 +59,11 @@ func (o *FeatureOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enable block profiling, if profiling is enabled")
 	fs.StringVar(&o.DebugSocketPath, "debug-socket-path", o.DebugSocketPath,
 		"Use an unprotected (no authn/authz) unix-domain socket for profiling with the given path")
+	fs.BoolVar(&o.EnablePriorityAndFairness, "enable-priority-and-fairness", o.EnablePriorityAndFairness, ""+
+		"If true and the APIPriorityAndFairness feature gate is enabled, replace the max-in-flight handler with an enhanced one that queues and dispatches with priority and fairness")
 }
 
-func (o *FeatureOptions) ApplyTo(c *server.Config) error {
+func (o *FeatureOptions) ApplyTo(c *server.Config, clientset kubernetes.Interface, informers informers.SharedInformerFactory) error {
 	if o == nil {
 		return nil
 	}
@@ -60,6 +71,19 @@ func (o *FeatureOptions) ApplyTo(c *server.Config) error {
 	c.EnableProfiling = o.EnableProfiling
 	c.DebugSocketPath = o.DebugSocketPath
 	c.EnableContentionProfiling = o.EnableContentionProfiling
+
+	if o.EnablePriorityAndFairness && feature.DefaultFeatureGate.Enabled(features.APIPriorityAndFairness) {
+		if c.MaxRequestsInFlight+c.MaxMutatingRequestsInFlight <= 0 {
+			return fmt.Errorf("invalid configuration: MaxRequestsInFlight=%d and MaxMutatingRequestsInFlight=%d; they must add up to something positive", c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight)
+
+		}
+		c.FlowControl = utilflowcontrol.New(
+			informers,
+			clientset.FlowcontrolV1beta3(),
+			c.MaxRequestsInFlight+c.MaxMutatingRequestsInFlight,
+			c.RequestTimeout/4,
+		)
+	}
 
 	return nil
 }

--- a/vendor/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -62,8 +62,7 @@ type ServerRunOptions struct {
 	// decoded in a write request. 0 means no limit.
 	// We intentionally did not add a flag for this option. Users of the
 	// apiserver library can wire it to a flag.
-	MaxRequestBodyBytes       int64
-	EnablePriorityAndFairness bool
+	MaxRequestBodyBytes int64
 
 	// ShutdownSendRetryAfter dictates when to initiate shutdown of the HTTP
 	// Server during the graceful termination of the apiserver. If true, we wait
@@ -104,7 +103,6 @@ func NewServerRunOptions() *ServerRunOptions {
 		ShutdownWatchTerminationGracePeriod: defaults.ShutdownWatchTerminationGracePeriod,
 		JSONPatchMaxCopyBytes:               defaults.JSONPatchMaxCopyBytes,
 		MaxRequestBodyBytes:                 defaults.MaxRequestBodyBytes,
-		EnablePriorityAndFairness:           true,
 		ShutdownSendRetryAfter:              false,
 	}
 }
@@ -324,9 +322,6 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"a request open before timing it out. Currently only honored by the watch request "+
 		"handler, which picks a randomized value above this number as the connection timeout, "+
 		"to spread out load.")
-
-	fs.BoolVar(&s.EnablePriorityAndFairness, "enable-priority-and-fairness", s.EnablePriorityAndFairness, ""+
-		"If true and the APIPriorityAndFairness feature gate is enabled, replace the max-in-flight handler with an enhanced one that queues and dispatches with priority and fairness")
 
 	fs.DurationVar(&s.ShutdownDelayDuration, "shutdown-delay-duration", s.ShutdownDelayDuration, ""+
 		"Time to delay the termination. During that time the server keeps serving requests normally. The endpoints /healthz and /livez "+

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -864,7 +864,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.28.3 => github.com/openshift/kubernetes-apiserver v0.0.0-20240112142943-d5600c13f38a
+# k8s.io/apiserver v0.28.3 => github.com/openshift/kubernetes-apiserver v0.0.0-20240312083446-be9e4a60dde6
 ## explicit; go 1.20
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/cel
@@ -1443,7 +1443,7 @@ sigs.k8s.io/yaml
 # k8s.io/api => k8s.io/api v0.28.3
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.3
 # k8s.io/apimachinery => k8s.io/apimachinery v0.28.3
-# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20240112142943-d5600c13f38a
+# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20240312083446-be9e4a60dde6
 # k8s.io/cli-runtime => k8s.io/cli-runtime v0.28.3
 # k8s.io/client-go => k8s.io/client-go v0.28.3
 # k8s.io/cloud-provider => k8s.io/cloud-provider v0.28.3


### PR DESCRIPTION
pulls https://github.com/openshift/kubernetes-apiserver/pull/55 so that apf can be disabled by passing `--enable-priority-and-fairness=false` flag. 

requires also updating the operator