### PR TITLE
OCPBUGS-57611: Updating ose-oauth-apiserver-container image to be consistent with ART for 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-nofips-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/images/Dockerfile.rhel7
+++ b/images/Dockerfile.rhel7
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-nofips-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/oauth-apiserver
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oauth-apiserver/oauth-apiserver /usr/bin/
 ENTRYPOINT ["/usr/bin/oauth-apiserver"]
 LABEL io.k8s.display-name="OpenShift OAuth API Server Command" \


### PR DESCRIPTION
Rebasing https://github.com/openshift/oauth-apiserver/pull/134 now that the go-1.24 images are available