### PR TITLE
CNTRLPLANE-3715: Agentic-SDLC: Add human and agent context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## What This Is
+
+The OpenShift oauth-apiserver is a Kubernetes aggregated API server serving the `oauth.openshift.io` and `user.openshift.io` API groups. It also acts as a Kubernetes Webhook Token Authenticator. It runs as part of the OpenShift control plane, proxied by kube-apiserver, and shares etcd for storage.
+
+The binary has two subcommands: `start` (runs the aggregated API server) and `external-oidc` (runs a standalone webhook token authenticator for external OIDC).
+
+## Build and Test Commands
+
+```sh
+make build              # Build binaries (oauth-apiserver + oauth-apiserver-tests-ext)
+make test               # Run unit tests (./pkg/... ./cmd/...)
+make verify             # Verify generated files are up-to-date
+make update             # Re-generate conversions, deep copies, defaulters, openapi
+make test-e2e           # Run e2e tests (requires a running OpenShift cluster)
+```
+
+Run a single unit test:
+```sh
+go test ./pkg/tokenvalidation/... -run TestMyFunction -count=1
+```
+
+Run a specific e2e test:
+```sh
+WHAT=TestName make run-e2e-test
+```
+
+## Architecture
+
+### Server Composition (Delegation Chain)
+
+The server uses Kubernetes API server delegation chaining. In `pkg/apiserver/apiserver.go`, the `New()` method builds the chain bottom-up:
+
+1. **Empty delegate** (base)
+2. **OAuth API server** (`pkg/oauth/apiserver/`) — registers `oauth.openshift.io` resources
+3. **User API server** (`pkg/user/apiserver/`) — registers `user.openshift.io` resources
+4. **Top-level GenericAPIServer** — ties them together
+
+Each sub-server gets a shallow-copied `GenericConfig` with PostStartHooks cleared to prevent double registration.
+
+### API Group Structure
+
+Each API group follows the same internal layout:
+
+- `pkg/{oauth,user}/apis/{group}/` — internal (hub) types
+- `pkg/{oauth,user}/apis/{group}/v1/` — versioned types and conversions
+- `pkg/{oauth,user}/apis/{group}/install/` — scheme registration
+- `pkg/{oauth,user}/apis/{group}/validation/` — validation logic
+- `pkg/{oauth,user}/apiserver/` — API server wiring, installs REST storage
+- `pkg/{oauth,user}/apiserver/registry/` — per-resource REST storage and strategy implementations (each resource has a `strategy.go` + `etcd/` subdirectory)
+
+The `pkg/api/install/` package registers both groups into the server's scheme.
+
+### External OIDC (`pkg/externaloidc/`)
+
+A separate subsystem for external OIDC authentication, invoked via the `external-oidc` subcommand. It runs a standalone HTTPS webhook server (not the aggregated API server). Key sub-packages:
+
+- `apis/authentication/` — internal types, versioned types (v1alpha1), validation, conversion for external OIDC config
+- `authenticator/jwt/` — JWT authenticator with external claim sourcing
+- `cel/` — CEL expression compilation for claim mappings and external source URLs
+- `oidc/externalclaims/resolver/` — fetches claims from external HTTP sources at authentication time
+- `server/` — standalone HTTPS server for webhook token authentication
+- `cmd/` — cobra command wiring
+
+### Token Validation (`pkg/tokenvalidation/`)
+
+Handles OAuth access token authentication and timeout-based invalidation. The `TimeoutValidator` runs a background goroutine that periodically flushes expired tokens.
+
+### Etcd Storage Prefixes
+
+Etcd prefixes are hardcoded for backward compatibility with historical OpenShift data (e.g., `oauth/accesstokens`, `useridentities`). These cannot be changed without a data migration. See `specialDefaultResourcePrefixes` in `pkg/cmd/oauth-apiserver/cmd.go`.
+
+## Code Conventions
+
+- Follow [Kubernetes Code Conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md).
+- All exported and unexported types/functions/methods should have descriptive Go doc comments.
+- Wrap errors with meaningful context. Follow [Kubernetes Logging Conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/logging.md).
+- Use table-driven tests. All changes must include unit tests.
+- Use dashes (not underscores) in command-line flags.
+- Vendor dependencies with `go mod vendor`. Do not add new dependencies without strong justification.
+
+## Generated Files
+
+After any API type changes (including `openshift/api` dependency bumps), run `make verify` to check and `make update` to regenerate. Generated files include conversions, deep copies, defaulters, and OpenAPI definitions. The generators are invoked via `hack/update-generated-*.sh` scripts.
+
+## Key Reference Files
+
+- `ARCHITECTURE.md` — detailed architecture, trade-offs, and design decisions with line-number references
+- `CONTRIBUTING.md` — full code conventions, testing guidelines, PR process, and CI/CD details
+
+## CI
+
+OpenShift uses Prow for CI. Job configs live in [openshift/release](https://github.com/openshift/release/tree/main/ci-operator/config/openshift). PR titles should be prefixed with a Jira ticket (e.g., `CNTRLPLANE-XXXX:`) or `NO-JIRA:`. Use `/retest` to retry flaky checks.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,135 @@
+# Architecture
+
+## Overview
+
+The OpenShift oauth-apiserver is an [aggregated API server](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) and [webhook token authenticator](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication) that extends the capabilities of the Kubernetes API server.
+
+From an architecture perspective, this essentially means that the oauth-apiserver is an HTTP server that
+implements its API interfaces in the same way that the Kubernetes API server does.
+
+We use the [Kubernetes API Aggregation Layer](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) to register these new APIs via the [`APIService` resource](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/api-service-v1/).
+
+## High-level Diagram
+
+```mermaid
+architecture-beta
+    group ocp(cloud)[OpenShift Cluster]
+
+    service etcd(database)[etcd] in ocp
+    service kubeapiserver(server)[kubeapiserver] in ocp
+    service oauthapiserver(server)[oauthapiserver] in ocp
+
+    junction junctionCenter
+
+    kubeapiserver:R -- L:junctionCenter
+    junctionCenter:R -- L:oauthapiserver
+    junctionCenter:B -- T:etcd
+```
+
+When the kube-apiserver receives a request for a resource served by the oauth-apiserver, it acts a proxy and will forward the request
+to the oauth-apiserver.
+
+Both the kube-apiserver and the oauth-apiserver share the same etcd instances for storage.
+
+For authentication requests that are forwarded to the oauth-apiserver, the kube-apiserver uses the [`TokenReview` API](https://kubernetes.io/docs/reference/kubernetes-api/definitions/token-review-v1-authentication/) to request validation of a provided token.
+If the token is valid, the oauth-apiserver responds with user metadata by setting the `.status` field in the `TokenReview` and returns it in it's response.
+
+A more detailed diagram of how the oauth-apiserver fits into the overall architecture of the OpenShift Control Plane can be found at https://miro.com/app/board/uXjVLrZngX4=/?moveToWidget=3458764614022295631&cot=10
+
+## Dependencies
+
+The key dependencies this project has are:
+- [openshift/kubernetes-apiserver](https://github.com/openshift/kubernetes-apiserver) - our fork of the Kubernetes `apiserver` library that is used for writing API servers.
+- [openshift/api](https://github.com/openshift/api) - Mono-repo of core OpenShift API definitions.
+
+
+## Trade-Offs / Decisions
+
+### Bootstrap User Uses ClusterAdminGroup Instead of SystemPrivilegedGroup
+The bootstrap authenticator assigns `ClusterAdminGroup` rather than `SystemPrivilegedGroup` because the latter cannot be properly scoped. API aggregation with delegated authorization (via `WithAlwaysAllowGroups`) makes `SystemPrivilegedGroup` impossible to control. This makes the bootstrap user susceptible to RBAC authorizer failures, but this is considered an acceptable trade-off because scopes must always be evaluated before RBAC for them to work at all. Alternative approaches were considered and rejected: a custom authorizer tied to a secret-derived extra value would require sharing `BootstrapUserDataGetter` logic between the kube API server and osin, breaking the current encapsulation where only the `BootstrapUser` constant is shared.
+- `pkg/tokenvalidation/bootstrapauthenticator.go:98-111`
+
+### Hardcoded TokenReview Authorization to Avoid Cyclical Checks
+The oauth-apiserver provides an authentication webhook. To avoid cyclical authorization checks when the kube-apiserver calls back to the oauth-apiserver for token validation, the expected user is hardcoded with a tokenreview permission via `NewHardCodedTokenReviewAuthorizer()`. Since this rule could never logically be removed in an OpenShift cluster, this approach is considered acceptable over a dynamic authorization check.
+- `pkg/cmd/oauth-apiserver/cmd.go:168-174`
+
+### Etcd Storage Prefixes for Backward Compatibility
+The etcd storage prefix (`openshift.io`) and per-resource storage prefixes (e.g., `oauth/accesstokens`, `useridentities`) match historical values used by earlier versions of OpenShift so that resources migrate cleanly. These values cannot change without a data migration.
+- `pkg/cmd/oauth-apiserver/cmd.go:35-36`
+- `pkg/cmd/oauth-apiserver/cmd.go:201-210`
+
+### Skip Explicit ApplyWithStorageFactoryTo to Prevent Double Health Check Registration
+The storage factory setup deliberately avoids calling `ApplyWithStorageFactoryTo` explicitly because `ApplyTo` was already called, which set up etcd health endpoints. Calling it again would cause double registration of storage-related health checks.
+- `pkg/cmd/oauth-apiserver/cmd.go:176-189`
+
+### Non-Root Apiserver Must Skip OpenAPI Installation
+The oauth-apiserver sets `SkipOpenAPIInstallation = true` because non-root apiservers must not install the default OpenAPI handler. OpenAPI is handled by the OpenAPI aggregator (both v2 and v3) at the root level.
+- `pkg/cmd/oauth-apiserver/cmd.go:159-162`
+
+### External Claims: Partial Evaluation Preferred Over Hard Failure
+When fetching claims from sources external to the JWT, errors are logged but not returned. Partial evaluation of external claim sources is preferred over failing entirely so that authentication is not wholly dependent on the availability of external sources. Authentication may be in a degraded state if external sources are unavailable, but it will not be blocked.
+- `pkg/externaloidc/oidc/externalclaims/resolver/resolver.go:196-205`
+
+### External Claims: 500ms Per-Request Timeout
+Each request to an external claims source uses a 500ms timeout. This allows up to 10 sequential external source requests before reaching 5 seconds, which is half the default Kubernetes API server timeout (10s) for webhook authenticator requests. This leaves at least 5 seconds for the rest of the claim mapping logic to execute.
+- `pkg/externaloidc/oidc/externalclaims/resolver/resolver.go:54-61`
+
+### External Claims: Intentional Overwriting of Existing Token Claims
+When external claims are merged into the token's claim map, existing claims with the same key are intentionally overwritten. While this has tradeoffs, the expectation is that end-users will primarily fetch claims not already present in their tokens. There are valid use cases where admins want to intentionally override claims, so this behavior is documented and admins can use sourcing conditions as a guard.
+- `pkg/externaloidc/oidc/externalclaims/resolver/resolver.go:262-272`
+- `pkg/externaloidc/apis/authentication/types.go:371-376`
+
+### External Claims: No Response Size Limit (Pending Performance Data)
+The response body from external claims sources is read without a size limit (`io.ReadAll` rather than `io.LimitReader`). This is a deliberate deferral: without comprehensive performance testing, there is no data-backed foundation for a reasonable maximum response size. Once testing provides that data, the implementation should move to `io.LimitReader`.
+- `pkg/externaloidc/oidc/externalclaims/resolver/resolver.go:347-354`
+
+### External Claims: CEL Expressions Use `any` Return Type
+CEL expressions for external source URLs return `any` because at compile time the types of claims in the token are unknown. The return value is explicitly validated after expression evaluation at runtime instead.
+- `pkg/externaloidc/cel/accessors.go:52-58`
+
+### External Claims: 256-Character Claim Name Limit
+Externally sourced claim names are capped at 256 characters to align with general best practices for token claim names. While token claims have no formally enforced limit, claims are included in request headers where short names are standard practice. 256 characters is considered sufficiently long for any reasonably named claim.
+- `pkg/externaloidc/apis/authentication/validation/validation.go:260-266`
+
+### Upstream Divergence: JWT Configuration is Required
+Unlike upstream Kubernetes, the OpenShift implementation requires at least one JWT authenticator to be specified in the authentication configuration. This diverges from upstream because external OIDC is an opt-in feature and it does not make sense to allow users to configure it without specifying any authentication configuration.
+- `pkg/externaloidc/apis/authentication/validation/validation_test.go:35-39`
+
+### Upstream Divergence: Disallowed Issuers Not Yet Implemented
+The OpenShift implementation does not yet support configuring disallowed issuers, which upstream uses to prevent configuring an authenticator for things like the service account issuer. This is a known gap intended to be addressed in the future.
+- `pkg/externaloidc/apis/authentication/validation/validation_test.go:260-263`
+
+### Identity and ClientAuthorization Names Are Immutable Formats
+The computed name formats for identities (`provider:identity`) and OAuth client authorizations (`userName:clientName`) cannot change because they must match resources already persisted in etcd. Changing these formats would cause unpredictable behavior for existing client authorizations and break identity lookups.
+- `pkg/user/apiserver/registry/identity/strategy.go:49-52`
+- `pkg/oauth/apiserver/registry/oauthclientauthorization/strategy.go:130-133`
+
+### User-Identity Mapping Operations Tolerate Partial Cleanup Failures
+When updating or deleting user-identity mappings, the primary operation (updating the identity's user reference) is performed first. If subsequent cleanup operations fail (removing the identity reference from the old user, or removing the user reference from the identity), errors are logged but execution continues. This is because the cleanup operations are no longer re-entrant at that point — retrying would not produce the correct result, and the critical mapping state has already been updated.
+- `pkg/user/apiserver/registry/useridentitymapping/rest.go:175-180`
+- `pkg/user/apiserver/registry/useridentitymapping/rest.go:203-209`
+
+### Timeout Validator: Flush Overlap Margin
+The token timeout validator adds a 10-second safety margin to its ticker interval so that consecutive flush cycles tend to overlap slightly rather than have gaps, preventing windows where expired tokens could be missed.
+- `pkg/tokenvalidation/timeoutvalidator.go:197-200`
+
+### Timeout Validator: Non-Blocking Token Updates via Goroutine
+After a positive timeout check, the token update is scheduled via a goroutine to avoid blocking the authentication request path.
+- `pkg/tokenvalidation/timeoutvalidator.go:100-102`
+
+### TokenReview Uses Internal Type Conversion to Avoid OpenAPI Errors
+The TokenReview REST handler converts from the v1 external type to the internal type before delegating to the wrapped handler. This avoids "cannot find model definition" errors that occur when internal types are used in `New()`.
+- `pkg/oauth/apiserver/registry/tokenreviews/etcd.go:58-63`
+
+### Test Server Returns Tear-Down Function Instead of Stop Channel
+The test server returns a tear-down function rather than a stop channel because Go testing's call to `os.Exit` does not give a stop channel goroutine enough time to remove temporary files, leading to leaked temporary files.
+- `pkg/cmd/oauth-apiserver/testing/testserver.go:45-48`
+
+### Copied Constants to Avoid Transitive Dependency on Kube
+Scope-related string constants (`UserIndicator`, `UserInfo`, `UserAccessCheck`) are copied from the apiserver-library-go repo rather than imported, to avoid a transitive dependency on kube for string constants.
+- `pkg/oauth/apiserver/registry/oauthclientauthorization/strategy_test.go:12`
+
+### Field Selector Conversion Per Group Version
+Field selector conversions are implemented as separate functions per group version (rather than a shared function) because field selector support can vary by the version under which a resource is exposed.
+- `pkg/oauth/apis/oauth/v1/conversion.go:25-26`
+- `pkg/user/apis/user/v1/conversion.go:15-16`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md) for full project context, build commands, architecture, and code conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,264 @@
+# Contributing to the OpenShift Control Plane Components/Repositories
+
+This document serves as a guide for contributing to the OpenShift components/repositories
+that the OpenShift Control Plane group is responsible for maintaining.
+
+This document is explicitly for contributions to individual component repositories and not for high-level
+feature proposals within OpenShift.
+
+Feature proposals should follow the OpenShift Enhancement Proposal process outlined in https://github.com/openshift/enhancements/blob/master/dev-guide/feature-zero-to-hero.md#openshift-feature-development-zero-to-hero-guide.
+If you are looking for a review on an OpenShift Enhancement Proposal that involves changes to components
+maintained by the control plane group, please request a review in the [`#forum-ocp-apiserver`](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel.
+
+This document contains the following sections:
+
+- [Code conventions](#code-conventions) - A collection of guidelines, style suggestions, and tips for writing code.
+- [Testing guidelines](#testing-guidelines) - Guidelines and expectations for testing of contributions.
+- [Pull Request process/guidelines](#pull-request-process-and-guidelines) - Guidelines and expectations of pull requests containing contributions.
+- [Review expectations](#review-expectations) - Guidelines and expectations for requesting reviews and interacting with reviewers.
+
+## Code Conventions
+
+We largely follow the [Kubernetes Code Conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md#code-conventions).
+
+Review both the Kubernetes Code Conventions and the ones specified here.
+There will be some overlap. If any conventions are at odds with one another, prefer the conventions explicitly documented here.
+
+### Bash
+
+- Follow the [shell styleguide](https://google.github.io/styleguide/shellguide.html).
+- Use [`shellcheck`](https://github.com/koalaman/shellcheck) to identify common mistakes or caveats.
+- Ensure that all scripts run consistently across Linux and MacOS.
+
+### Golang (Go)
+
+- Review [Effective Go](https://go.dev/doc/effective_go).
+- Review common [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+- Review and avoid [Go Landmines](https://gist.github.com/lavalamp/4bd23295a9f32706a48f)
+- Comment your code following the [Go comment conventions](https://go.dev/doc/comment).
+    - Comments should be meaningful and add context and/or explain choices that cannot be expressed through clear code.
+    - All exported types, functions, and methods must have descriptive comments.
+    - All unexported types, functions, and methods should have descriptive comments.
+- When adding command-line flags, use dashes/hyphens (`-`) and not underscores (`_`).
+- Naming
+    - Please consider package name when selecting an interface name, and avoid redundancy. For example, `storage.Interface` is better than `storage.StorageInterface`.
+    - Do not use uppercase characters, underscores, or dashes in package names.
+    - Please consider parent directory name when choosing a package name. For example, `pkg/controllers/autoscaler/foo.go` should say `package autoscaler` not `package autoscalercontroller`.
+        - Unless there's a good reason, the package foo line should match the name of the directory in which the .go file exists.
+        - Importers can use a different name if they need to disambiguate.
+    - Locks should be called `lock` and should never be embedded (always `lock sync.Mutex`). When multiple locks are present, give each lock a distinct name following Go conventions: `stateLock`, `mapLock` etc.
+- Error handling
+    - Wrap errors with meaningful context before returning or logging them.
+- When logging, follow the [Kubernetes Logging Conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/logging.md).
+- When patching OpenShift-maintained forks of "upstream" repositories, patches should be as small as reasonably possible and should minimize touch points with code that is likely to change and impact the rebasing process.
+- Dependencies must be vendored. When making changes to dependencies, ensure you've run `go mod tidy` and `go mod vendor`.
+- When a function accepts or has access to a `context.Context`, pass it through to downstream calls that accept one. Never discard a context or substitute `context.Background()`/`context.TODO()` when a context is already available.
+
+### General
+
+Regardless of the programming language, make sure to take the following into consideration:
+- Keep readability / maintainability in mind when writing code.
+    - Clever code and abstractions are often harder to reason about after the fact. Keep clever code and abstractions to the minimum necessary to accomplish the end-goal.
+- Do not reinvent the wheel. Where possible, use existing standard library or vendored library functionality. If you are adding a net-new dependency, stop and think if you _really_ need to add the new dependency to achieve your goals.
+- When writing tests, focus on testing the functional behaviors your code exercises. Avoid writing tests that are testing that the standard library works as expected or is trivial. Do not write tests just for line coverage.
+
+### Directory and File Conventions
+
+- Avoid package sprawl. Find an appropriate subdirectory for new packages.
+    - Libraries with no appropriate home belong in new package subdirectories of `pkg/util`.
+- Avoid general utility packages. Packages called "util" are suspect. Instead, derive a name that describes your desired function. For example, the utility functions dealing with waiting for operations are in the `wait` package and include functionality like `Poll`. The full name is `wait.Poll`.
+- All filenames should be lowercase.
+- Go source files and directories use underscores, not dashes.
+    - Package directories should generally avoid using separators as much as possible. When package names are multiple words, they usually should be in nested subdirectories.
+
+## Testing Guidelines
+
+These are high-level testing guidelines. Where individual component repositories may have
+additional testing guidelines to follow when making contributions.
+
+- All changes must include unit test additions/changes.
+    - Exceptions are at reviewer/approver discretion.
+- Table-driven unit tests are preferred for testing multiple scenarios/inputs. For an example, see https://github.com/openshift/cluster-authentication-operator/blob/a493799952e9b6838021ccc7d15d3d37d7ad3508/pkg/controllers/externaloidc/externaloidc_controller_test.go#L108 .
+- Unit tests must pass on all platforms (at the very least, Linux + MacOS).
+- Significant features should come with integration and/or end-to-end (e2e) tests where appropriate.
+    - End-to-end tests _may_ be scoped as a separate work item when the end-to-end tests for the component must be added to the openshift/origin repository instead of the component repository. Adding e2e tests to the component repository is preferred where possible. It is up to reviewer/approver discretion whether a contribution can be merged without end-to-end tests being implemented.
+- Do not expect an asynchronous thing to happen immediately. Do not wait for one second and expect a pod to be running. Wait and retry instead.
+
+
+If necessary, manual integration testing can be done by creating a cluster using the [`Cluster Bot` Slack App](https://redhat.enterprise.slack.com/archives/D03KX7M1CRJ).
+Once you have a cluster created, you can follow some of the instructions in https://github.com/openshift/enhancements/blob/master/dev-guide/operators.md for guidance on how to
+build component images and modify cluster-operators to deploy those images.
+
+Most component repos have existing tooling to run unit tests. Check for Makefiles and shell scripts that might run the unit tests. If none exist, you should be able to use standard testing tooling like `go test ./...` to run all tests for the project. https://pkg.go.dev/cmd/go/internal/test is a good reference for how the `go test` command works.
+
+## Pull Request Process and Guidelines
+
+This section assumes that you have a functional understanding of `git` and how to create a pull request on GitHub.
+
+If you do not, start with [GitHub's "Getting Started" guide](https://docs.github.com/en/get-started/start-your-journey).
+
+### Prerequisites
+
+Before you commit any changes or create any pull requests, you must adhere to OpenShift contribution policies.
+Currently, that means enabling commit signature verification.
+
+See https://docs.google.com/document/d/1184EPSGunUkcSQYUK8T4a6iyawwi6f2zxdbB2jtG9nQ/edit?usp=sharing for more details on
+how to adhere to the commit signature verification policy of OpenShift.
+
+### Creating a Pull Request
+
+When creating a pull request, include the following:
+
+- A brief, but descriptive, title.
+    - All pull requests _should_ link to a Jira ticket associated with the work. There is automation that performs this linking when prefixing the title with the Jira ticket identifier like: `CNTRLPLANE-XXXX: my pull request title`. For pull requests that have no Jira ticket associated with it, you can prefix it with `NO-JIRA:` to signal that there is not a Jira ticket associated with it.
+- A useful description of the changes being made and why they are important. Include links to supporting documents and any additional context that reviewers may need.
+
+### CI / CD
+
+For CI/CD, OpenShift uses Prow to run various checks. This can include unit tests, e2e tests, linters, etc.
+
+The jobs configured for each repository are in https://github.com/openshift/release/tree/main/ci-operator/config/openshift . If you find yourself needing to add additional jobs, review the documentation at https://docs.ci.openshift.org/how-tos/contributing-openshift-release/ .
+
+There are often a mixture of required and optional checks as well as merge criteria that must be met before a pull request can merge.
+When any of these checks fail, the GitHub Prow bot will leave a comment on the PR with links to the run of that check that failed.
+
+As the PR author, it is your responsibility to evaluate the failed checks and determine if there are any changes necessary to pass the checks.
+If you suspect that the check failure was a flake, you can trigger retests by commenting `/retest` (or `/retest-required` for retesting only the required checks) on the PR.
+
+### Verifying your changes / Creating an OpenShift cluster from a PR
+
+As part of merging a PR, there is a requirement to verify that the changes you've made are working as expected using the `/verified` comment command.
+
+While there are a lot of scenarios where the existing CI/CD checks may be sufficient to verify your changes are working (and can be denoted by commenting `/verified by ci`),
+there may be scenarios where manual verification is required.
+
+You can use the `Cluster Bot` Slack App to create a cluster from a PR by sending it a message in the format of `launch ${OCP_VERSION},${PR_LINK} ${PLATFORM},${VARIANT}`.
+As an example, `launch 4.23,https://github.com/openshift/cluster-authentication-operator/pull/928 aws,techpreview` would launch an OpenShift 4.23 cluster with the changes made in openshift/cluster-authentication-operator#928 running on AWS with the TechPreviewNoUpgrade feature-set enabled.
+For more information on what `Cluster Bot` can do, you can send it a message saying `help` and it will respond with additional documentation on how it can be used.
+
+Once you've verified your changes work as expected, you can mark the PR as verified by commenting `/verified by @{your_github_handle}` on the PR.
+
+### Additional Resources
+
+For more information regarding more general OpenShift pull request processes, the following resources are helpful:
+
+- https://docs.ci.openshift.org/architecture/jira
+- https://docs.ci.openshift.org/
+- https://steps.ci.openshift.org/ 
+
+## Review Expectations
+
+### Requesting a review
+
+If you are not a member of the OpenShift control plane team and you need a review on a PR, post it in the [#forum-ocp-apiserver](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel or
+reach out to folks outlined in the OWNERS file directly.
+
+If you are a member of the OpenShift control plane team, reviews should come from your feature team. In the event your feature team does not have someone that can approve
+a PR, post it in the [#control-plane](https://redhat.enterprise.slack.com/archives/CC3CZCQHM) Slack channel.
+
+OpenShift uses AI code review tools as part of the code review process.
+Before requesting a review, address all feedback from the code review agent(s).
+It is up to your discretion as the contributor how you would like to address that feedback.
+Responding with an explanation as to why you are not going to take action on a comment made
+by the agent is an acceptable way to "address" its feedback.
+
+### Interacting with reviewers
+
+When interacting with reviewers/approvers:
+
+- Be professional.
+- Be respectful of differing opinions, viewpoints, and experiences.
+- Gracefully give and receive constructive feedback.
+- Focus on what is best for the product/organization, not just us as individuals.
+
+A special note on the usage of AI - to respect the time of those that are reviewing your contribution, please do not use AI to respond to review comments.
+
+# `oauth-apiserver`-Specific Contributing Guidelines
+
+## Building
+
+### Binary
+
+To build the oauth-apiserver binary, run the following command:
+```sh
+make build
+```
+
+### Image
+
+To build an image for the oauth-apiserver:
+
+1. Log in to the [`app.ci` cluster](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/) using Red Hat SSO.
+2. Click on your username and then click on "Copy login command".
+3. Click "Display Token".
+4. Copy your token.
+5. Run `podman login registry.ci.openshift.org`.
+    - For your username, use your Kerberos ID (the same username shown in the OpenShift console for the `app.ci` cluster).
+    - For your password, use the token you copied.
+6. Run `podman build -f images/Dockerfile.rhel7 -t ${IMAGE_TAG} .`
+    - If you are using MacOS, you'll need to set the platform with the `--platform linux/amd64` flag to run the image on an OpenShift cluster.
+
+## Generated Files
+
+As this is an aggregated API server, there are a handful of generated files.
+Whenever you make changes to any of the APIs, including updates from bumping the `openshift/api` dependency, run:
+
+```sh
+make verify
+```
+
+To see if there are any changes that need to be made to the generated files.
+If this command fails, run:
+
+```sh
+make update
+```
+
+to re-generate the generated files and commit the changes.
+Once updated, you can re-run `make verify` to validate that everything is up-to-date.
+
+
+## Testing
+
+### Unit tests
+
+To run the unit tests for the entire project, run:
+
+```sh
+make test
+```
+
+### End-to-end tests
+
+This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+
+#### Building the test binary
+
+```bash
+make build
+```
+
+#### Running test suites and tests
+
+```bash
+# Run a specific test suite or test
+./oauth-apiserver-tests-ext run-suite "openshift/oauth-apiserver/all"
+./oauth-apiserver-tests-ext run-test "test-name"
+
+# Run with JUnit output
+./oauth-apiserver-tests-ext run-suite openshift/oauth-apiserver/all --junit-path /tmp/junit.xml
+```
+
+#### Listing available tests and suites
+
+```bash
+# List all test suites
+./oauth-apiserver-tests-ext list suites
+
+# List tests in a suite
+./oauth-apiserver-tests-ext list tests --suite=openshift/oauth-apiserver/all
+```
+
+For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+
+Beyond the OTE tests, there are some additional e2e tests that can be run with `make test-e2e`.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,70 @@
-## Tests
+# oauth-apiserver
+
+## Overview
+
+The OpenShift oauth-apiserver is an [aggregated API server](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) that is responsible
+for serving some of OpenShift's authentication and authorization related APIs.
+
+It also serves as a [Kubernetes Webhook Token Authenticator](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication).
+
+### Aggregated APIs served
+
+The oauth-apiserver serves both the `oauth.openshift.io` and `user.openshift.io` API groups.
+
+More details on the APIs in these groups can be found in the OpenShift documentation:
+- [oauth.openshift.io API Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/oauth_apis/oauth-apis)
+- [user.openshift.io API Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/user_and_group_apis/user-and-group-apis)
+
+Most of the user-facing API definitions for these groups will be found in the [openshift/api repository](https://github.com/openshift/api)
+
+## Contributing
+
+For guidance on contributing, see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Building
+
+### Binary
+
+To build the oauth-apiserver binary, run the following command:
+```sh
+make build
+```
+
+### Image
+
+To build an image for the oauth-apiserver:
+
+1. Log in to the [`app.ci` cluster](https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/) using Red Hat SSO.
+2. Click on your username and then click on "Copy login command".
+3. Click "Display Token".
+4. Copy your token.
+5. Run `podman login registry.ci.openshift.org`.
+    - For your username, use your Kerberos ID (the same username shown in the OpenShift console for the `app.ci` cluster).
+    - For your password, use the token you copied.
+6. Run `podman build -f images/Dockerfile.rhel7 -t ${IMAGE_TAG} .`
+    - If you are using MacOS, you'll need to set the platform with the `--platform linux/amd64` flag to run the image on an OpenShift cluster.
+
+## Testing
+
+### Unit tests
+
+To run the unit tests for the entire project, run:
+
+```sh
+make test
+```
+
+### End-to-end tests
 
 This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
 
-### Building the test binary
+#### Building the test binary
 
 ```bash
 make build
 ```
 
-### Running test suites and tests
+#### Running test suites and tests
 
 ```bash
 # Run a specific test suite or test
@@ -19,7 +75,7 @@ make build
 ./oauth-apiserver-tests-ext run-suite openshift/oauth-apiserver/all --junit-path /tmp/junit.xml
 ```
 
-### Listing available tests and suites
+#### Listing available tests and suites
 
 ```bash
 # List all test suites
@@ -30,3 +86,5 @@ make build
 ```
 
 For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+
+Beyond the OTE tests, there are some additional e2e tests that can be run with `make test-e2e`.


### PR DESCRIPTION
## Description

This PR adds/modifies the following files with more context about the oauth-apiserver component:
- README.md
- CONTRIBUTING.md
- ARCHITECTURE.md
- CLAUDE.md
- AGENTS.md

## Motivation

Aligns with our organizational goals of adding context to our component repos that are useful for both humans and agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new repository guidance for contributors, including build/test commands, coding conventions, and generated-file workflow.
  * Introduced an end-to-end architecture document covering the oauth-apiserver role, request flow, and key design trade-offs.
  * Added a short doc entry point linking to the broader guidance and architecture materials.
  * Reorganized the README to provide a clearer overview, structured contributing/build/testing sections, and updated end-to-end test instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->