### PR TITLE
CNTRLPLANE-2260: test migration of tokenreview tests to OTE

### DIFF
--- a/cmd/oauth-apiserver-tests-ext/dependencymagnet.go
+++ b/cmd/oauth-apiserver-tests-ext/dependencymagnet.go
@@ -1,0 +1,8 @@
+// This file imports test packages to ensure they are included in the build.
+// These imports are necessary to register Ginkgo tests with the OpenShift Tests Extension framework.
+package main
+
+import (
+	// Import test packages to register Ginkgo tests
+	_ "github.com/openshift/oauth-apiserver/test/e2e"
+)

--- a/cmd/oauth-apiserver-tests-ext/main.go
+++ b/cmd/oauth-apiserver-tests-ext/main.go
@@ -61,9 +61,20 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 	registry := oteextension.NewRegistry()
 	extension := oteextension.NewExtension("openshift", "payload", "oauth-apiserver")
 
+	// Parallel-safe, non-disruptive tests run with default (Stable) cluster
+	// health monitoring and no forced serialization.
+	extension.AddSuite(oteextension.Suite{
+		Name:    "openshift/oauth-apiserver/component/parallel",
+		Parents: []string{"openshift/conformance/parallel"},
+		Qualifiers: []string{
+			`name.contains("[Component]") && !name.contains("[Serial]") && !name.contains("[Disruptive]")`,
+		},
+	})
+
 	// Non-disruptive tests run with default (Stable) cluster health monitoring.
 	extension.AddSuite(oteextension.Suite{
 		Name:        "openshift/oauth-apiserver/component/serial",
+		Parents:     []string{"openshift/conformance/serial"},
 		Parallelism: 1,
 		Qualifiers: []string{
 			`name.contains("[Component]") && name.contains("[Serial]") && !name.contains("[Disruptive]")`,

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
+	github.com/onsi/ginkgo/v2 v2.28.1
+	github.com/onsi/gomega v1.39.1
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20260408205138-ec501c2bf4a5
 	github.com/openshift/api v0.0.0-20260727141720-967cc4c36c9b
 	github.com/openshift/apiserver-library-go v0.0.0-20260715200723-42e5e402ca43
@@ -88,8 +90,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.28.1 // indirect
-	github.com/onsi/gomega v1.39.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,0 +1,105 @@
+package e2e
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	kauthenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apiserver/pkg/storage/names"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	oauthv1client "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	userclient "github.com/openshift/client-go/user/clientset/versioned"
+)
+
+// tokenName computes the OAuthAccessToken resource name from a raw token secret.
+// The server hashes the secret part (after "sha256~") and stores it as sha256~<base64(hash)>.
+func tokenName(rawSecret string) string {
+	h := sha256.Sum256([]byte(rawSecret))
+	return "sha256~" + base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+var _ = g.Describe("[sig-auth] OAuth", func() {
+	g.It("should successfully review valid and invalid tokens [Component][apigroup:oauth.openshift.io]", func(ctx context.Context) {
+		t := g.GinkgoTB()
+		adminConfig := NewClientConfigForTest(t)
+		trashBin := NewResourceTrashbin(t, adminConfig)
+		defer trashBin.Empty(t)
+
+		userClient, err := userclient.NewForConfig(adminConfig)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oauthClient, err := oauthv1client.NewForConfig(adminConfig)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Use unique per-run names so that stale resources from a previous run or a
+		// parallel CI job cannot cause creation to fail with a name collision.
+		userName := names.SimpleNameGenerator.GenerateName("tokenreviews-e2e-testuser-")
+		clientName := names.SimpleNameGenerator.GenerateName("tokenreviews-e2e-client-")
+
+		user, err := userClient.UserV1().Users().Create(ctx, &userv1.User{
+			ObjectMeta: metav1.ObjectMeta{Name: userName},
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		trashBin.AddResource(userv1.GroupVersion.WithResource("users"), user.GetObjectMeta())
+
+		oauthClientObj, err := oauthClient.OAuthClients().Create(ctx, &oauthv1.OAuthClient{
+			ObjectMeta:   metav1.ObjectMeta{Name: clientName},
+			GrantMethod:  oauthv1.GrantHandlerAuto,
+			RedirectURIs: []string{"https://localhost/callback"},
+			ScopeRestrictions: []oauthv1.ScopeRestriction{
+				{ExactValues: []string{"user:info"}},
+			},
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		trashBin.AddResource(oauthv1.GroupVersion.WithResource("oauthclients"), oauthClientObj.GetObjectMeta())
+
+		// rawSecret is the value that will be sent in the TokenReview spec.
+		// The resource name is derived by hashing it. It is generated per run so
+		// the derived token name is unique too.
+		rawSecret := names.SimpleNameGenerator.GenerateName("tokenreviews-e2e-secret-")
+		accessToken, err := oauthClient.OAuthAccessTokens().Create(ctx, &oauthv1.OAuthAccessToken{
+			ObjectMeta:  metav1.ObjectMeta{Name: tokenName(rawSecret)},
+			ClientName:  clientName,
+			Scopes:      []string{"user:info"},
+			RedirectURI: "https://localhost/callback",
+			ExpiresIn:   3600,
+			UserName:    user.Name,
+			UserUID:     string(user.UID),
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		trashBin.AddResource(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), accessToken.GetObjectMeta())
+
+		// review a token that does not exist — expect not authenticated
+		result := &kauthenticationv1.TokenReview{}
+		err = oauthClient.RESTClient().Post().
+			Resource("tokenreviews").
+			Body(&kauthenticationv1.TokenReview{
+				Spec: kauthenticationv1.TokenReviewSpec{Token: "sha256~doesnotexist"}, // notsecret
+			}).
+			Do(ctx).Into(result)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result.Status.Authenticated).To(o.BeFalse())
+
+		// review the valid token — expect authenticated
+		result = &kauthenticationv1.TokenReview{}
+		err = oauthClient.RESTClient().Post().
+			Resource("tokenreviews").
+			Body(&kauthenticationv1.TokenReview{
+				Spec: kauthenticationv1.TokenReviewSpec{Token: "sha256~" + rawSecret},
+			}).
+			Do(ctx).Into(result)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result.Status.Authenticated).To(o.BeTrue())
+		// Assert the authenticated identity so a regression that authenticates the
+		// wrong principal is caught, not just the boolean.
+		o.Expect(result.Status.User.Username).To(o.Equal(user.Name))
+		o.Expect(result.Status.User.UID).To(o.Equal(string(user.UID)))
+	})
+})

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -26,7 +27,7 @@ import (
 )
 
 // NewClientConfigForTest returns a config configured to connect to the api server
-func NewClientConfigForTest(t *testing.T) *rest.Config {
+func NewClientConfigForTest(t testing.TB) *rest.Config {
 	loader := clientcmd.NewDefaultClientConfigLoadingRules()
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, &clientcmd.ConfigOverrides{ClusterInfo: api.Cluster{InsecureSkipTLSVerify: true}})
 	config, err := clientConfig.ClientConfig()
@@ -91,7 +92,7 @@ func waitForSelfSAR(interval, timeout time.Duration, c kubernetes.Interface, sel
 
 // PortForwardSvc forwards a remote service's port to localhost
 // portMapping is a string "localPort:remotePort"
-func PortForwardSvc(t *testing.T, svcNS, svcName, portMapping string) context.CancelFunc {
+func PortForwardSvc(t testing.TB, svcNS, svcName, portMapping string) context.CancelFunc {
 	var err error
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
@@ -135,7 +136,7 @@ type ResourceTrashbin struct {
 }
 
 // NewResourceTrashbin creates an instance of a ResourceTrashbin
-func NewResourceTrashbin(t *testing.T, adminKubeconfig *rest.Config) *ResourceTrashbin {
+func NewResourceTrashbin(t testing.TB, adminKubeconfig *rest.Config) *ResourceTrashbin {
 	dynamicClient, err := dynamic.NewForConfig(adminKubeconfig)
 	require.NoError(t, err)
 
@@ -158,12 +159,22 @@ func (b *ResourceTrashbin) AddResource(resource schema.GroupVersionResource, obj
 }
 
 // Empty deletes all of the cached resources
-func (b *ResourceTrashbin) Empty(t *testing.T) {
+func (b *ResourceTrashbin) Empty(t testing.TB) {
 	for _, r := range b.resourcesToDelete {
+		// Bound each cleanup request so a stalled Delete cannot block deferred
+		// cleanup indefinitely (the test rest.Config sets no client timeout).
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		err := b.dynamicClient.
 			Resource(r.Resource).
 			Namespace(r.Namespace).
-			Delete(context.Background(), r.Name, metav1.DeleteOptions{})
+			Delete(ctx, r.Name, metav1.DeleteOptions{})
+		cancel()
+		// A resource may already be gone (e.g. deleted by the test itself or via
+		// cascade); only a non-NotFound error means cleanup actually failed.
+		if err != nil && !apierrors.IsNotFound(err) {
+			t.Errorf("failed to delete %v: %v", r, err)
+			continue
+		}
 		t.Logf("Deleted %v, err: %v", r, err)
 	}
 


### PR DESCRIPTION
[CNTRLPLANE-2260](https://redhat.atlassian.net/browse/CNTRLPLANE-2260): tokenreview tests migrated to
OTE framework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the OAuth TokenReview flow, validating invalid-token rejection and successful authentication with the expected user identity.

* **Tests**
  * Integrated the OAuth e2e suite with the test extension framework.
  * Improved test helper compatibility across supported testing contexts.
  * Enhanced test cleanup to continue safely when resources are already absent and report other cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->