### PR TITLE
CNTRLPLANE-3947: hack/update-openapi-spec: prefer REGISTRY_AUTH_FILE over cluster profile pull secret

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -143,12 +143,12 @@ echo "Using OpenShift release: ${OPENSHIFT_RELEASE}"
 
 # Set up registry authentication if available
 REGISTRY_AUTH_OPTS=""
-if [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
-  echo "Using pull secret from ${CLUSTER_PROFILE_DIR}/pull-secret"
-  REGISTRY_AUTH_OPTS="--registry-config=${CLUSTER_PROFILE_DIR}/pull-secret"
-elif [[ -n "${REGISTRY_AUTH_FILE:-}" && -f "${REGISTRY_AUTH_FILE}" ]]; then
+if [[ -n "${REGISTRY_AUTH_FILE:-}" && -f "${REGISTRY_AUTH_FILE}" ]]; then
   echo "Using pull secret from ${REGISTRY_AUTH_FILE}"
   REGISTRY_AUTH_OPTS="--registry-config=${REGISTRY_AUTH_FILE}"
+elif [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
+  echo "Using pull secret from ${CLUSTER_PROFILE_DIR}/pull-secret"
+  REGISTRY_AUTH_OPTS="--registry-config=${CLUSTER_PROFILE_DIR}/pull-secret"
 else
   echo "WARNING: No pull secret found. Proceeding without authentication."
   echo "This may fail if accessing private registries."


### PR DESCRIPTION
Check `REGISTRY_AUTH_FILE` before `CLUSTER_PROFILE_DIR/pull-secret` so the CI job config can provide credentials for registries not covered by the cluster profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registry authentication selection to prioritize `REGISTRY_AUTH_FILE` when both authentication sources are available.
  * Preserved the existing fallback behavior when `REGISTRY_AUTH_FILE` is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->