### PR TITLE
NO-JIRA: Remove cluster profile directory authentication as it is no longer injected in CI

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -136,10 +136,7 @@ fi
 #
 # Registry auth:
 #   oc resolves credentials via REGISTRY_AUTH_FILE, ~/.config/containers/auth.json,
-#   or ~/.docker/config.json (see oc's auth_resolver.go). For backward compatibility
-#   with CI configs that set cluster_profile, the script also checks
-#   CLUSTER_PROFILE_DIR/pull-secret and exports it as REGISTRY_AUTH_FILE so oc
-#   picks it up automatically.
+#   or ~/.docker/config.json (see oc's auth_resolver.go).
 
 if [[ -z "${ETCD_IMAGE:-}" ]]; then
   OPENSHIFT_RELEASE="${OPENSHIFT_RELEASE:-}"
@@ -163,17 +160,6 @@ if [[ -z "${ETCD_IMAGE:-}" ]]; then
   fi
   echo "Using release: ${OPENSHIFT_RELEASE}"
 
-fi
-
-# Registry auth is needed even when ETCD_IMAGE is pre-set,
-# because oc image extract still needs credentials to pull the image.
-if [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
-  echo "Using pull secret from ${CLUSTER_PROFILE_DIR}/pull-secret"
-  export REGISTRY_AUTH_FILE="${CLUSTER_PROFILE_DIR}/pull-secret"
-else
-  echo "WARNING: No explicit registry credentials found."
-  echo "Falling back to oc's default credential discovery (REGISTRY_AUTH_FILE, ~/.docker/config.json, ~/.config/containers/auth.json)."
-  echo "This may fail if accessing private registries."
 fi
 
 echo "Extracting etcd..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated registry authentication guidance to rely on the command-line tool’s default credential discovery.
  * Removed references to automatic pull-secret usage and related credential warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->